### PR TITLE
pass plugin configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ useHighlighter     : false    // When 'true' markdown-it will use highlight.js
 ### Using markdown-it Plugins
 If you want to use markdown-it plugins you can do this by installing the package in your project and overwriting the plugins configuration option.
 
+Plugin options are specified as configuration options using the plugin name with any dashes (-) converted to underscores (_).
+
 #### Example
 Say you want to use footnotes, markdown-it has a [plugin](https://github.com/markdown-it/markdown-it-footnote) for this. To enable this plugin you will first have to install the package. You can do this by running the following command from your project folder:
 ```
@@ -65,6 +67,7 @@ docpadConfig:
 		<the other plugins you need to configure>
 		markit:
 			plugins: ['markdown-it-footnote']
+            markdown_it_footnote: {...}
 ```
 
 ## Credits

--- a/src/markit.plugin.coffee
+++ b/src/markit.plugin.coffee
@@ -52,7 +52,9 @@ module.exports = (BasePlugin) ->
 
 				# Load the plugins defined by the docpad.coffee file
 				for plugin in config.plugins
-					markedIt.use(require(plugin))
+					pluginConfig = plugin.replace(/-/g, "_")
+					pluginOpts = if config[pluginConfig] then config[pluginConfig] else {}
+					markedIt.use(require(plugin), pluginOpts)
 
 				# Render the markdown content
 				opts.content = markedIt.render opts.content


### PR DESCRIPTION
Some markdown-it plugins need options.

```
require('markdown-it')()
        .use(require('markdown-it-checkbox'),{
          divWrap: true,
          divClass: 'cb',
          idPrefix: 'cbx_'
        });
```

These changes allow those options to be specified in `docpad.coffee` and passed to the plugin.

```
docpadConfig:
    <whatever else is in your config>
    plugins:
        <the other plugins you need to configure>
        markit:
            plugins: ['markdown-it-checkbox']
            markdown_it_checkbox: {divWrap: true, divClass: 'cb', idPrefix: 'cbx_'}
```
